### PR TITLE
add code coverage output dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.nyc_output


### PR DESCRIPTION
many people following the "how to git" tutorial are doing a `git commit -a` after running the test suite, and this pulls in extra files in `.nyc_output`.